### PR TITLE
feat: allow hostnames in IP field

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ services:
         machines:
           - name: desktop
             mac: "00:11:22:33:44:55"
-            ip: "192.168.1.100"
+            ip: "192.168.1.100" # Optional, for status checking
           - name: server
             mac: "AA:BB:CC:DD:EE:FF"
-            ip: "192.168.1.101"
+            ip: "server.local"
         server:
-          listen: ":7777"
+          listen: ":7777" # Optional, defaults to :7777
 ```
 
 Check out `examples/reverse-proxy.yml` for an example of running wol behind
@@ -95,7 +95,7 @@ machines:
     ip: "192.168.1.100" # Optional, for status checking
   - name: server
     mac: "AA:BB:CC:DD:EE:FF"
-    ip: "192.168.1.101" # Optional, for status checking
+    ip: "server.local"
 
 server:
   listen: ":7777" # Optional, defaults to :7777
@@ -111,7 +111,7 @@ machines:
     ip: "192.168.1.100" # Optional, for status checking
   - name: server
     mac: "AA:BB:CC:DD:EE:FF"
-    ip: "192.168.1.101" # Optional, for status checking
+    ip: "server.local"
 
 server:
   listen: ":7777" # Optional, defaults to :7777

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"log"
-	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -122,15 +121,8 @@ func getMachineStatus(machine config.Machine) (string, error) {
 	if machine.IP == nil {
 		return "unknown", nil
 	}
-	ip := net.ParseIP(*machine.IP)
-	if ip == nil {
-		return "unknown", fmt.Errorf("invalid IP address: %s", *machine.IP)
-	}
 
-	// if !isAddressReachable(ip) {
-	// 	return "offline", nil
-	// }
-	reachable, err := isAddressReachable(ip)
+	reachable, err := isAddressReachable(*machine.IP)
 	if err != nil {
 		return "unknown", err
 	}
@@ -208,8 +200,8 @@ func handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func isAddressReachable(ip net.IP) (bool, error) {
-	pinger, err := probing.NewPinger(ip.String())
+func isAddressReachable(addr string) (bool, error) {
+	pinger, err := probing.NewPinger(addr)
 	if err != nil {
 		return false, fmt.Errorf("error creating pinger: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ type Machine struct {
 	Name string `koanf:"name"`
 	// MAC address of the machine
 	Mac string `koanf:"mac"`
-	// IP address of the machine (optional)
+	// Hostname or IP address of the machine (optional)
 	IP *string `koanf:"ip"`
 }
 


### PR DESCRIPTION
This PR improves hostname handling as discussed in https://github.com/Trugamr/wol/issues/13.

- Make configuration more flexible by accepting any valid hostname
- Let `probing` handle all address formats natively