### PR TITLE
Add HTTP support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,8 +26,34 @@ type Machine struct {
 	Name string `koanf:"name"`
 	// MAC address of the machine
 	Mac string `koanf:"mac"`
+	// Use HTTP instead of UDP
+	HTTP *HTTP `koanf:"http"`
 	// Hostname or IP address of the machine (optional)
 	IP *string `koanf:"ip"`
+}
+
+type WakeMethod int
+
+const (
+	WakeMethodUDP WakeMethod = iota
+	WakeMethodHTTP
+)
+
+func (m *Machine) WakeMethod() WakeMethod {
+	if m.HTTP != nil {
+		return WakeMethodHTTP
+	}
+	return WakeMethodUDP
+}
+
+// HTTP represents the configuration for waking a machine over HTTP
+type HTTP struct {
+	// Endpoint to send the HTTP request to
+	Endpoint string `koanf:"endpoint"`
+	// HTTP method to use (e.g. GET, POST)
+	Method string `koanf:"method"`
+	// Request body (optional)
+	Body string `koanf:"body"`
 }
 
 // Server represents the server configuration


### PR DESCRIPTION
Hi,

First of all, thank you for the great project, I really love how simple and elegant the UI is.

I'm looking for some feedback on this rough draft of a PR for adding HTTP support.
My end goal is to be able to use a single device to host wol, and then be able to wake devices on different subnets. Since that doesn't work over UDP, HTTP was the next-best option, specifically using Tailscale.

However, as I continued writing out the logic, I realized that Tailscale has some specific logic (such as the headers it requires), and every additional Tailscale-specific feature needs to be modifiable by the end user to be usable generically.

So I guess I see 3 options:
1. Add an additional flag for setting headers, and potentially open up a can of worms for future requests.
2. Make it a Tailscale-specific implementation, and don't expose a general HTTP implementation (e.g. config file just has something like `tailscale-device: my-device-name`).
3. Make it an arbitrary command implementation, where the user supplies a single command to be run instead of sending a magic packet (and all of the fun security issues that pop up with remote arbitrary command execution).

Please let me know if you have any preferences/ideas. Thanks!