### PR TITLE
feature: support 'http://IP/wake?name=MACHINENAME' as url parameter

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -33,6 +33,7 @@ var serveCmd = &cobra.Command{
 
 		mux.HandleFunc("GET /{$}", handleIndex)
 		mux.HandleFunc("POST /wake", handleWake)
+		mux.HandleFunc("GET /wake", handleWake)
 		mux.HandleFunc("GET /status", handleStatus)
 
 		log.Printf("Listening on %s", cfg.Server.Listen)


### PR DESCRIPTION
Adds support for URL parameters to specify what machine to wake, such as `http://192.168.0.123/wake?name=Laptop` by adding a 'get' endpoint. Just a one line addition. I wanted to use a simple browser bookmark to wake up one of my machines, and this was a surprisingly easy fix. #8 was close, but I couldn't easily get a post to behave itself in a standard browser bookmark and work with my auth redirect (I use tinyauth).

In terms of security implications, I don't think it's huge as while a bookmark or other link could be directed to that URL, the damage would be mitigated to waking the machine only, and just like the main page of wol, it should always be behind a firewall or other authorization system.

I tested in my browser, and with `curl "http://localhost:7777/wake?name=desktop"` and it operated as expected. Existing POST behavior with `curl -X POST http://localhost:7777/wake -d "name=desktop"` continued to operate as expected.