### PR TITLE
test: add automated test suite

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/trugamr/wol/config"
 	"github.com/trugamr/wol/magicpacket"
 )
 
@@ -52,7 +53,7 @@ var sendCmd = &cobra.Command{
 			}
 
 			// Find machine with the specified name
-			mac, err = getMacByName(name)
+			mac, err = getMacByName(cfg.Machines, name)
 			if err != nil {
 				cobra.CheckErr(err)
 			}
@@ -71,8 +72,8 @@ var sendCmd = &cobra.Command{
 }
 
 // getMacByName returns the MAC address of the machine with the specified name
-func getMacByName(name string) (net.HardwareAddr, error) {
-	for _, machine := range cfg.Machines {
+func getMacByName(machines []config.Machine, name string) (net.HardwareAddr, error) {
+	for _, machine := range machines {
 		if strings.EqualFold(machine.Name, name) {
 			mac, err := net.ParseMAC(machine.Mac)
 			if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -29,21 +31,52 @@ var serveCmd = &cobra.Command{
 	Long:  "Serve a web interface that lists all the configured machines and allows you to wake them up",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		mux := http.NewServeMux()
-
-		mux.HandleFunc("GET /{$}", handleIndex)
-		mux.HandleFunc("POST /wake", handleWake)
-		mux.HandleFunc("GET /status", handleStatus)
+		handler := newServer(cfg, newProbingPinger(cfg.Ping.Privileged), broadcastWake).routes()
 
 		log.Printf("Listening on %s", cfg.Server.Listen)
-		err := http.ListenAndServe(cfg.Server.Listen, mux)
+		err := http.ListenAndServe(cfg.Server.Listen, handler)
 		if err != nil {
 			cobra.CheckErr(err)
 		}
 	},
 }
 
-func handleIndex(w http.ResponseWriter, r *http.Request) {
+// Pinger reports whether a network address is currently reachable.
+type Pinger interface {
+	Reachable(addr string) (bool, error)
+}
+
+// waker sends a wake-on-LAN magic packet to the given MAC address.
+type waker func(mac net.HardwareAddr) error
+
+// broadcastWake is the production waker: it broadcasts a real magic packet.
+func broadcastWake(mac net.HardwareAddr) error {
+	return magicpacket.NewMagicPacket(mac).Broadcast()
+}
+
+// server holds the dependencies for the web handlers. Injecting them (rather
+// than reaching for package globals) lets tests substitute fakes for the pinger
+// and wake action, so handlers can be exercised without real ICMP or UDP traffic.
+type server struct {
+	cfg    *config.Config
+	pinger Pinger
+	wake   waker
+}
+
+func newServer(cfg *config.Config, pinger Pinger, wake waker) *server {
+	return &server{cfg: cfg, pinger: pinger, wake: wake}
+}
+
+// routes registers all HTTP routes and returns the handler.
+func (s *server) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{$}", s.handleIndex)
+	mux.HandleFunc("POST /wake", s.handleWake)
+	mux.HandleFunc("GET /status", s.handleStatus)
+	return mux
+}
+
+func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	// Parse the template
 	index, err := template.ParseFS(templates, "templates/index.html")
 	if err != nil {
@@ -54,7 +87,7 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 
 	// Execute the template
 	data := map[string]interface{}{
-		"Machines":     cfg.Machines,
+		"Machines":     s.cfg.Machines,
 		"Version":      version,
 		"Commit":       commit,
 		"Date":         date,
@@ -94,17 +127,16 @@ func consumeFlashMessage(w http.ResponseWriter, r *http.Request) string {
 	return ""
 }
 
-func handleWake(w http.ResponseWriter, r *http.Request) {
+func (s *server) handleWake(w http.ResponseWriter, r *http.Request) {
 	machineName := r.FormValue("name")
-	mac, err := getMacByName(machineName)
+	mac, err := getMacByName(s.cfg.Machines, machineName)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	log.Printf("Sending magic packet to %s", mac)
-	mp := magicpacket.NewMagicPacket(mac)
-	if err := mp.Broadcast(); err != nil {
+	if err := s.wake(mac); err != nil {
 		log.Printf("Error sending magic packet: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -116,14 +148,15 @@ func handleWake(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
-// getMachineStatus returns the status of a machine
-func getMachineStatus(machine config.Machine) (string, error) {
+// machineStatus returns the status of a single machine.
+func (s *server) machineStatus(machine config.Machine) (string, error) {
 	if machine.IP == nil {
 		return "unknown", nil
 	}
 
-	reachable, err := isAddressReachable(*machine.IP)
+	reachable, err := s.pinger.Reachable(*machine.IP)
 	if err != nil {
+		fmt.Println(err)
 		return "unknown", err
 	}
 	if reachable {
@@ -133,17 +166,17 @@ func getMachineStatus(machine config.Machine) (string, error) {
 	return "offline", nil
 }
 
-// getMachinesStatus returns a map of machine names to their statuses concurrently
-func getMachinesStatus() map[string]string {
+// machinesStatus returns a map of machine names to their statuses concurrently.
+func (s *server) machinesStatus() map[string]string {
 	var mu sync.Mutex
 	statuses := make(map[string]string)
 	var wg sync.WaitGroup
 
-	for _, machine := range cfg.Machines {
+	for _, machine := range s.cfg.Machines {
 		wg.Add(1)
 		go func(machine config.Machine) {
 			defer wg.Done()
-			status, err := getMachineStatus(machine)
+			status, err := s.machineStatus(machine)
 			if err != nil {
 				log.Printf("Error getting status for machine %s: %v", machine.Name, err)
 				return
@@ -160,31 +193,40 @@ func getMachinesStatus() map[string]string {
 	return statuses
 }
 
-func handleStatus(w http.ResponseWriter, r *http.Request) {
+// writeMachinesStatus writes a single SSE frame with the current status of all
+// machines to w, flushing if w supports it. Extracted from the streaming loop so
+// the frame can be tested without running the loop.
+func (s *server) writeMachinesStatus(w io.Writer) error {
+	statuses := s.machinesStatus()
+	data, err := json.Marshal(statuses)
+	if err != nil {
+		return fmt.Errorf("error marshaling status: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+		return fmt.Errorf("error writing status: %w", err)
+	}
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	return nil
+}
+
+func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	// Sends the current status of all machines
-	sendMachinesStatus := func() {
-		statuses := getMachinesStatus()
-		data, err := json.Marshal(statuses)
-		if err != nil {
-			log.Printf("Error marshaling status: %v", err)
-			return
+	send := func() {
+		if err := s.writeMachinesStatus(w); err != nil {
+			log.Print(err)
 		}
-
-		_, err = fmt.Fprintf(w, "data: %s\n\n", data)
-		if err != nil {
-			log.Printf("Error writing status: %v", err)
-			return
-		}
-
-		w.(http.Flusher).Flush()
 	}
 
 	// Sends initial status
-	sendMachinesStatus()
+	send()
 
 	// Send status updates every few seconds
 	ticker := time.NewTicker(5 * time.Second)
@@ -195,18 +237,27 @@ func handleStatus(w http.ResponseWriter, r *http.Request) {
 		case <-r.Context().Done():
 			return
 		case <-ticker.C:
-			sendMachinesStatus()
+			send()
 		}
 	}
 }
 
-func isAddressReachable(addr string) (bool, error) {
+// probingPinger is the production Pinger, backed by pro-bing.
+type probingPinger struct {
+	privileged bool
+}
+
+func newProbingPinger(privileged bool) *probingPinger {
+	return &probingPinger{privileged: privileged}
+}
+
+func (p *probingPinger) Reachable(addr string) (bool, error) {
 	pinger, err := probing.NewPinger(addr)
 	if err != nil {
-		return false, fmt.Errorf("error creating pinger: %v", err)
+		return false, fmt.Errorf("error creating pinger: %w", err)
 	}
 	// Set privileged mode based on config
-	pinger.SetPrivileged(cfg.Ping.Privileged)
+	pinger.SetPrivileged(p.privileged)
 
 	// We only want to ping once and wait 2 seconds for a response
 	pinger.Timeout = 2 * time.Second
@@ -214,14 +265,9 @@ func isAddressReachable(addr string) (bool, error) {
 
 	err = pinger.Run()
 	if err != nil {
-		return false, fmt.Errorf("error pinging: %v", err)
+		return false, fmt.Errorf("error pinging: %w", err)
 	}
 
 	// If we receive even a single packet, the address is reachable
-	stats := pinger.Statistics()
-	if stats.PacketsRecv == 0 {
-		return false, nil
-	}
-
-	return true, nil
+	return pinger.Statistics().PacketsRecv > 0, nil
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trugamr/wol/config"
+)
+
+func strptr(s string) *string { return &s }
+
+// fakePinger is a test Pinger that returns canned reachability per address.
+type fakePinger struct {
+	reachable map[string]bool
+}
+
+func (f fakePinger) Reachable(addr string) (bool, error) {
+	return f.reachable[addr], nil
+}
+
+func TestHandleIndexRendersMachines(t *testing.T) {
+	cfg := &config.Config{
+		Machines: []config.Machine{{Name: "alpha", Mac: "01:02:03:04:05:06"}},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	newServer(cfg, nil, nil).routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "alpha")
+}
+
+func TestHandleWakeSuccess(t *testing.T) {
+	const macStr = "01:02:03:04:05:06"
+	cfg := &config.Config{
+		Machines: []config.Machine{{Name: "alpha", Mac: macStr}},
+	}
+
+	var gotMac net.HardwareAddr
+	wake := func(mac net.HardwareAddr) error {
+		gotMac = mac
+		return nil
+	}
+	req := httptest.NewRequest(http.MethodPost, "/wake", strings.NewReader("name=alpha"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	newServer(cfg, nil, wake).routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "/", rec.Header().Get("Location"))
+
+	// The configured machine's MAC was parsed and handed to the wake seam.
+	want, err := net.ParseMAC(macStr)
+	require.NoError(t, err)
+	assert.Equal(t, want, gotMac)
+
+	// A flash message cookie naming the machine is set.
+	var flash *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "flash" {
+			flash = c
+		}
+	}
+	require.NotNil(t, flash)
+	assert.Contains(t, flash.Value, "alpha")
+}
+
+func TestHandleWakeMachineNotFound(t *testing.T) {
+	cfg := &config.Config{
+		Machines: []config.Machine{{Name: "alpha", Mac: "01:02:03:04:05:06"}},
+	}
+
+	called := false
+	wake := func(mac net.HardwareAddr) error {
+		called = true
+		return nil
+	}
+	req := httptest.NewRequest(http.MethodPost, "/wake", strings.NewReader("name=ghost"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	newServer(cfg, nil, wake).routes().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.False(t, called, "wake must not be called for an unknown machine")
+}
+
+func TestWriteMachinesStatusFrame(t *testing.T) {
+	cfg := &config.Config{
+		Machines: []config.Machine{
+			{Name: "on", IP: strptr("10.0.0.1")},
+			{Name: "off", IP: strptr("10.0.0.2")},
+			{Name: "unknown", IP: nil},
+		},
+	}
+	pinger := fakePinger{reachable: map[string]bool{
+		"10.0.0.1": true,
+		"10.0.0.2": false,
+	}}
+	var buf bytes.Buffer
+	require.NoError(t, newServer(cfg, pinger, nil).writeMachinesStatus(&buf))
+
+	out := buf.String()
+	require.True(t, strings.HasPrefix(out, "data: "), "frame must start with an SSE data field")
+	require.True(t, strings.HasSuffix(out, "\n\n"), "frame must end with a blank line")
+
+	payload := strings.TrimSuffix(strings.TrimPrefix(out, "data: "), "\n\n")
+	var statuses map[string]string
+	require.NoError(t, json.Unmarshal([]byte(payload), &statuses))
+	assert.Equal(t, map[string]string{
+		"on":      "online",
+		"off":     "offline",
+		"unknown": "unknown",
+	}, statuses)
+}
+
+func TestGetMacByName(t *testing.T) {
+	machines := []config.Machine{
+		{Name: "alpha", Mac: "01:02:03:04:05:06"},
+		{Name: "badmac", Mac: "not-a-mac"},
+	}
+
+	tests := []struct {
+		name      string
+		lookup    string
+		wantMAC   string
+		wantError bool
+	}{
+		{name: "exact match", lookup: "alpha", wantMAC: "01:02:03:04:05:06"},
+		{name: "case-insensitive match", lookup: "ALPHA", wantMAC: "01:02:03:04:05:06"},
+		{name: "not found", lookup: "ghost", wantError: true},
+		{name: "invalid mac", lookup: "badmac", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mac, err := getMacByName(machines, tt.lookup)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMAC, mac.String())
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -16,9 +16,8 @@ const (
 	koanfDelimiter = "."
 	koanfTag       = "koanf"
 	configFilename = "config.yaml"
+	configEnvVar   = "WOL_CONFIG"
 )
-
-var k = koanf.New(koanfDelimiter)
 
 // Machine represents a machine to wake up
 type Machine struct {
@@ -68,20 +67,6 @@ func NewConfig() *Config {
 //
 // 3. Environment variable `WOL_CONFIG` containing full YAML config
 func (c *Config) Load() error {
-	// Load defaults first
-	defaults := &Config{
-		Server: Server{
-			Listen: ":7777",
-		},
-		Ping: Ping{
-			Privileged: false,
-		},
-	}
-	err := k.Load(structs.Provider(defaults, koanfTag), nil)
-	if err != nil {
-		return fmt.Errorf("failed to load defaults: %w", err)
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("failed to get home directory: %w", err)
@@ -94,8 +79,34 @@ func (c *Config) Load() error {
 		filepath.Join(".", configFilename),
 	}
 
+	return c.load(paths)
+}
+
+// load reads configuration into c from the given file paths (in precedence order,
+// later overriding earlier) layered on top of the defaults, then applies the
+// WOL_CONFIG environment variable override.
+//
+// It uses a fresh koanf instance per call so repeated loads don't accumulate
+// state, and takes its search paths as an argument so tests can point it at
+// temporary files instead of the real /etc/wol or ~/.wol.
+func (c *Config) load(paths []string) error {
+	k := koanf.New(koanfDelimiter)
+
+	// Load defaults first
+	defaults := &Config{
+		Server: Server{
+			Listen: ":7777",
+		},
+		Ping: Ping{
+			Privileged: false,
+		},
+	}
+	if err := k.Load(structs.Provider(defaults, koanfTag), nil); err != nil {
+		return fmt.Errorf("failed to load defaults: %w", err)
+	}
+
 	for _, path := range paths {
-		err = k.Load(file.Provider(path), yaml.Parser())
+		err := k.Load(file.Provider(path), yaml.Parser())
 
 		// Ignore error if file does not exist
 		if err != nil && !os.IsNotExist(err) {
@@ -104,14 +115,12 @@ func (c *Config) Load() error {
 	}
 
 	// Load from `WOL_CONFIG` environment variable if set
-	ec := []byte(os.Getenv("WOL_CONFIG"))
-	err = k.Load(rawbytes.Provider(ec), yaml.Parser())
-	if err != nil {
-		return fmt.Errorf("failed to load config from WOL_CONFIG: %w", err)
+	ec := []byte(os.Getenv(configEnvVar))
+	if err := k.Load(rawbytes.Provider(ec), yaml.Parser()); err != nil {
+		return fmt.Errorf("failed to load config from %s: %w", configEnvVar, err)
 	}
 
-	err = k.Unmarshal("", c)
-	if err != nil {
+	if err := k.Unmarshal("", c); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfig writes content to a config file in a fresh temp dir and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), configFilename)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestLoadDefaults(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	c := NewConfig()
+	require.NoError(t, c.load(nil))
+
+	assert.Equal(t, ":7777", c.Server.Listen)
+	assert.False(t, c.Ping.Privileged)
+	assert.Empty(t, c.Machines)
+}
+
+func TestLoadFilePrecedence(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	lower := writeConfig(t, `
+server:
+  listen: ":1111"
+ping:
+  privileged: true
+machines:
+  - name: alpha
+    mac: "01:02:03:04:05:06"
+`)
+	higher := writeConfig(t, `
+server:
+  listen: ":2222"
+machines:
+  - name: beta
+    mac: "0a:0b:0c:0d:0e:0f"
+`)
+
+	c := NewConfig()
+	require.NoError(t, c.load([]string{lower, higher}))
+
+	// Later file overrides the listen address...
+	assert.Equal(t, ":2222", c.Server.Listen)
+	// ...while a key only the earlier file set is preserved.
+	assert.True(t, c.Ping.Privileged)
+	// Slices are replaced wholesale, not merged: the higher-precedence
+	// machines list wins entirely.
+	require.Len(t, c.Machines, 1)
+	assert.Equal(t, "beta", c.Machines[0].Name)
+}
+
+func TestLoadWOLConfigOverride(t *testing.T) {
+	file := writeConfig(t, `
+server:
+  listen: ":1111"
+`)
+	t.Setenv(configEnvVar, `
+server:
+  listen: ":9999"
+`)
+
+	c := NewConfig()
+	require.NoError(t, c.load([]string{file}))
+
+	// WOL_CONFIG overrides values from config files.
+	assert.Equal(t, ":9999", c.Server.Listen)
+}
+
+func TestLoadMissingFilesIgnored(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	c := NewConfig()
+	// Missing files are skipped rather than failing the load.
+	require.NoError(t, c.load([]string{missing}))
+	assert.Equal(t, ":7777", c.Server.Listen)
+}
+
+func TestLoadMalformedYAML(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	bad := writeConfig(t, "machines: [unterminated\n")
+
+	c := NewConfig()
+	require.Error(t, c.load([]string{bad}))
+}
+
+func TestLoadDoesNotShareState(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	withMachine := writeConfig(t, `
+machines:
+  - name: alpha
+    mac: "01:02:03:04:05:06"
+`)
+
+	first := NewConfig()
+	require.NoError(t, first.load([]string{withMachine}))
+	require.Len(t, first.Machines, 1)
+
+	// A second load with no files must not inherit the first load's machines.
+	// Guards against regressing to a shared package-global koanf instance.
+	second := NewConfig()
+	require.NoError(t, second.load(nil))
+	assert.Empty(t, second.Machines)
+	assert.Equal(t, ":7777", second.Server.Listen)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/knadh/koanf/v2 v2.3.5
 	github.com/prometheus-community/pro-bing v0.9.0
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
@@ -21,9 +23,11 @@ require (
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=

--- a/magicpacket/magicpacket.go
+++ b/magicpacket/magicpacket.go
@@ -1,6 +1,18 @@
 package magicpacket
 
-import "net"
+import (
+	"io"
+	"net"
+)
+
+const (
+	// A magic packet is a 6-byte 0xFF sync stream followed by the MAC repeated 16 times.
+	packetSize     = 102
+	syncStreamSize = 6
+	macRepeatCount = 16
+
+	broadcastPort = 9
+)
 
 // MagicPacket represents a wake-on-LAN packet
 type MagicPacket struct {
@@ -13,24 +25,31 @@ func NewMagicPacket(macAddress net.HardwareAddr) *MagicPacket {
 	return &MagicPacket{MacAddress: macAddress}
 }
 
-// Broadcast sends the magic packet to the broadcast address
-func (p *MagicPacket) Broadcast() error {
-	// Build the actual packet
-	packet := make([]byte, 102)
-	// Set the synchronization stream (first 6 bytes are 0xFF)
-	for i := 0; i < 6; i++ {
+// Bytes returns the raw magic packet payload.
+func (p *MagicPacket) Bytes() []byte {
+	packet := make([]byte, packetSize)
+	for i := 0; i < syncStreamSize; i++ {
 		packet[i] = 0xFF
 	}
-	// Copy the MAC address 16 times into the packet
-	for i := 1; i <= 16; i++ {
+	for i := 1; i <= macRepeatCount; i++ {
 		copy(packet[i*6:], p.MacAddress)
 	}
+	return packet
+}
 
-	// Broadcast the packet
-	// TODO: Broadcast to more common ports and addresses?
+// WriteTo writes the packet to w. It implements io.WriterTo so the send path can
+// be tested against an in-memory writer instead of the network.
+func (p *MagicPacket) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(p.Bytes())
+	return int64(n), err
+}
+
+// Broadcast sends the magic packet to the broadcast address
+func (p *MagicPacket) Broadcast() error {
+	// TODO: broadcast to more common ports and addresses?
 	addr := &net.UDPAddr{
 		IP:   net.IPv4bcast,
-		Port: 9,
+		Port: broadcastPort,
 	}
 	conn, err := net.DialUDP("udp", nil, addr)
 	if err != nil {
@@ -38,6 +57,6 @@ func (p *MagicPacket) Broadcast() error {
 	}
 	defer conn.Close()
 
-	_, err = conn.Write(packet)
+	_, err = p.WriteTo(conn)
 	return err
 }

--- a/magicpacket/magicpacket_test.go
+++ b/magicpacket/magicpacket_test.go
@@ -1,0 +1,54 @@
+package magicpacket
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMagicPacketBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		mac  string
+	}{
+		{name: "typical mac", mac: "01:02:03:04:05:06"},
+		{name: "all ones mac", mac: "ff:ff:ff:ff:ff:ff"},
+		{name: "zero mac", mac: "00:00:00:00:00:00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mac, err := net.ParseMAC(tt.mac)
+			require.NoError(t, err)
+
+			packet := NewMagicPacket(mac).Bytes()
+
+			require.Len(t, packet, 102)
+			assert.Equal(t, bytes.Repeat([]byte{0xFF}, 6), packet[:6])
+
+			// MAC repeated 16 times after the sync stream.
+			for i := 0; i < 16; i++ {
+				start := 6 + i*6
+				assert.Equalf(t, []byte(mac), packet[start:start+6],
+					"MAC repetition %d at offset %d", i+1, start)
+			}
+		})
+	}
+}
+
+func TestMagicPacketWriteTo(t *testing.T) {
+	mac, err := net.ParseMAC("01:02:03:04:05:06")
+	require.NoError(t, err)
+
+	mp := NewMagicPacket(mac)
+
+	var buf bytes.Buffer
+	n, err := mp.WriteTo(&buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(102), n)
+	assert.Equal(t, mp.Bytes(), buf.Bytes())
+}


### PR DESCRIPTION
## Summary
Adds the first automated test suite for `wol`, plus a small refactor that makes the web layer testable. No functional changes to the CLI or web UI.

## Changes
- **magicpacket:** split packet building from network I/O (`Bytes()` + `WriteTo(io.Writer)`); table-driven tests for the 102-byte layout.
- **config:** split `Load()` into a path-resolving wrapper + an injectable `load(paths)` with a fresh koanf instance per call; hermetic tests for defaults, file precedence, `WOL_CONFIG` override, malformed YAML, and missing files.
- **serve (web layer):** carry handler dependencies on a `server` struct (config, a `Pinger` interface around pro-bing, and a wake func) instead of package globals; httptest coverage for the index, wake (success + not-found), the status SSE frame, and name→MAC lookup.
- Adds `testify` as a test dependency.

## Testing
- `go test -race -cover ./...` — green (config 60%, magicpacket 56%, cmd 43.5%)
- `go vet ./...` and `go build ./...` clean

Part of ME-7, ME-8, ME-9, ME-10