### PR TITLE
ci: build, vet, test, and lint on push and pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege: CI only needs to read the code. Using the pull_request event
+# (never pull_request_target) means PRs from forks run with this read-only token
+# and no access to repository secrets.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+      - run: goreleaser check
+      - run: goreleaser build --snapshot --clean --single-target

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,29 +15,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,8 @@ builds:
       - -X github.com/trugamr/wol/cmd.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -36,7 +37,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 dockers:
   - image_templates:

--- a/magicpacket/magicpacket.go
+++ b/magicpacket/magicpacket.go
@@ -45,7 +45,7 @@ func (p *MagicPacket) WriteTo(w io.Writer) (int64, error) {
 }
 
 // Broadcast sends the magic packet to the broadcast address
-func (p *MagicPacket) Broadcast() error {
+func (p *MagicPacket) Broadcast() (err error) {
 	// TODO: broadcast to more common ports and addresses?
 	addr := &net.UDPAddr{
 		IP:   net.IPv4bcast,
@@ -55,7 +55,12 @@ func (p *MagicPacket) Broadcast() error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	// Surface a close error, but don't let it mask a write error.
+	defer func() {
+		if cerr := conn.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	_, err = p.WriteTo(conn)
 	return err


### PR DESCRIPTION
Adds a CI workflow that gates every push to `main` and every pull request. Until now nothing ran outside the tag-triggered release pipeline.

## Jobs (parallel)
- **test** — `go build ./...`, `go vet ./...`, `go test -race ./...`
- **lint** — golangci-lint v2 (`.golangci.yml`, `standard` linters + gofmt/goimports)
- **goreleaser** — `goreleaser check` + `goreleaser build --snapshot --clean --single-target` to validate the release pipeline without publishing

## Security
- Triggers on `pull_request` (never `pull_request_target`), so fork PRs run with a **read-only token and no access to secrets**.
- Top-level `permissions: contents: read`; no secrets referenced anywhere. Publishing stays in the tag-only release workflow.
- `concurrency` cancels superseded runs.

Go version comes from `go.mod` via `go-version-file`. Actions pinned to current majors (checkout v6, setup-go v6, golangci-lint-action v9, goreleaser-action v7).

Part of ME-6
