### PR TITLE
feat: add --config flag to set config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Create a `config.yaml` file in one of these locations (in order of precedence):
 - `~/.wol/config.yaml` (home directory)
 - `/etc/wol/config.yaml` (system-wide)
 
+To load a config file from an arbitrary path, pass `-c`/`--config`:
+
+```sh
+wol serve --config /etc/wol/config.yaml
+```
+
+An explicit `--config` file is authoritative: it must exist (wol exits with an
+error if it doesn't), and the default search locations above and the `WOL_CONFIG`
+environment variable are ignored. This is handy for systemd units, e.g.
+`ExecStart=wol serve --config /etc/wol/config.yaml`. On startup `serve` logs which
+config source it loaded.
+
 Alternatively, you can provide the configuration via the `WOL_CONFIG` environment variable:
 
 ```sh
@@ -138,6 +150,9 @@ wol send --mac "00:11:22:33:44:55"
 
 # Start the web interface
 wol serve
+
+# Start the web interface with an explicit config file
+wol serve --config /etc/wol/config.yaml
 
 # Show version information
 wol version

--- a/README.md
+++ b/README.md
@@ -95,9 +95,8 @@ wol serve --config /etc/wol/config.yaml
 
 An explicit `--config` file is authoritative: it must exist (wol exits with an
 error if it doesn't), and the default search locations above and the `WOL_CONFIG`
-environment variable are ignored. This is handy for systemd units, e.g.
-`ExecStart=wol serve --config /etc/wol/config.yaml`. On startup `serve` logs which
-config source it loaded.
+environment variable are ignored. On startup `serve` logs which config source it
+loaded.
 
 Alternatively, you can provide the configuration via the `WOL_CONFIG` environment variable:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,14 +7,31 @@ import (
 	"github.com/trugamr/wol/config"
 )
 
-var cfg = config.NewConfig()
+var (
+	cfg = config.NewConfig()
+	// cfgFile is the explicit config path from --config; empty means search the
+	// default locations.
+	cfgFile string
+	// configSources records which sources contributed to the loaded config, so
+	// commands can report them (see serve).
+	configSources []string
+)
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file path (overrides the default search locations)")
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "wol",
 	Short: "Discover and wake up devices on the network",
 	Long:  "Discover devices on the network and wake them by sending magic Wake-On-LAN packets",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		return cfg.Load()
+		sources, err := cfg.Load(cfgFile)
+		if err != nil {
+			return err
+		}
+		configSources = sources
+		return nil
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,9 +12,6 @@ var (
 	// cfgFile is the explicit config path from --config; empty means search the
 	// default locations.
 	cfgFile string
-	// configSources records which sources contributed to the loaded config, so
-	// commands can report them (see serve).
-	configSources []string
 )
 
 func init() {
@@ -26,12 +23,7 @@ var rootCmd = &cobra.Command{
 	Short: "Discover and wake up devices on the network",
 	Long:  "Discover devices on the network and wake them by sending magic Wake-On-LAN packets",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		sources, err := cfg.Load(cfgFile)
-		if err != nil {
-			return err
-		}
-		configSources = sources
-		return nil
+		return cfg.Load(cfgFile)
 	},
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +32,12 @@ var serveCmd = &cobra.Command{
 	Long:  "Serve a web interface that lists all the configured machines and allows you to wake them up",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(configSources) > 0 {
+			log.Printf("Loaded config from %s", strings.Join(configSources, ", "))
+		} else {
+			log.Print("No config file found; using built-in defaults")
+		}
+
 		handler := newServer(cfg, newProbingPinger(cfg.Ping.Privileged), broadcastWake).routes()
 
 		log.Printf("Listening on %s", cfg.Server.Listen)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,8 +32,8 @@ var serveCmd = &cobra.Command{
 	Long:  "Serve a web interface that lists all the configured machines and allows you to wake them up",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(configSources) > 0 {
-			log.Printf("Loaded config from %s", strings.Join(configSources, ", "))
+		if sources := cfg.Sources(); len(sources) > 0 {
+			log.Printf("Loaded config from %s", strings.Join(sources, ", "))
 		} else {
 			log.Print("No config file found; using built-in defaults")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,10 @@ type Config struct {
 	Server Server `koanf:"server"`
 	// Ping represents the ping configuration
 	Ping Ping `koanf:"ping"`
+
+	// sources records which inputs contributed to the loaded config, in load
+	// order. It is unexported so koanf's reflection-based providers ignore it.
+	sources []string
 }
 
 // NewConfig creates a new Config instance
@@ -56,8 +60,14 @@ func NewConfig() *Config {
 	return &Config{}
 }
 
-// Load loads the configuration and returns the sources that contributed to it,
-// in load order (later values override earlier ones).
+// Sources returns the inputs that contributed to the last Load, in load order
+// (e.g. config file paths and the WOL_CONFIG environment variable).
+func (c *Config) Sources() []string {
+	return c.sources
+}
+
+// Load loads the configuration. The contributing sources are recorded and can be
+// retrieved with Sources (in load order, later values overriding earlier ones).
 //
 // If path is non-empty it is used as the sole config file and must exist (a
 // missing file is an error). An explicit --config file is authoritative: the
@@ -70,25 +80,31 @@ func NewConfig() *Config {
 //   - ./config.yaml
 //
 // In all cases the built-in defaults are the lowest-priority layer.
-func (c *Config) Load(path string) ([]string, error) {
+func (c *Config) Load(path string) error {
 	// An explicit config file replaces the default search locations and must exist.
-	if path != "" {
-		return c.load([]string{path}, true)
+	paths := []string{path}
+	explicit := true
+
+	if path == "" {
+		explicit = false
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		// Order here matters as later values will override earlier ones
+		paths = []string{
+			filepath.Join("/etc", "wol", configFilename),
+			filepath.Join(home, ".wol", configFilename),
+			filepath.Join(".", configFilename),
+		}
 	}
 
-	home, err := os.UserHomeDir()
+	sources, err := c.load(paths, explicit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
+		return err
 	}
-
-	// Order here matters as later values will override earlier ones
-	paths := []string{
-		filepath.Join("/etc", "wol", configFilename),
-		filepath.Join(home, ".wol", configFilename),
-		filepath.Join(".", configFilename),
-	}
-
-	return c.load(paths, false)
+	c.sources = sources
+	return nil
 }
 
 // load reads configuration into c from the given file paths (in precedence order,

--- a/config/config.go
+++ b/config/config.go
@@ -154,15 +154,13 @@ func (c *Config) load(paths []string, explicit bool) ([]string, error) {
 		sources = append(sources, path)
 	}
 
-	// An explicit --config file is authoritative and used on its own; WOL_CONFIG
-	// only applies when discovering configuration automatically.
-	if !explicit {
-		if ec := os.Getenv(configEnvVar); ec != "" {
-			if err := k.Load(rawbytes.Provider([]byte(ec)), yaml.Parser()); err != nil {
-				return nil, fmt.Errorf("failed to load config from %s: %w", configEnvVar, err)
-			}
-			sources = append(sources, configEnvVar+" environment variable")
+	// WOL_CONFIG overrides the discovered files; an explicit --config file is
+	// authoritative, so the env var is ignored in that mode.
+	if ec := os.Getenv(configEnvVar); !explicit && ec != "" {
+		if err := k.Load(rawbytes.Provider([]byte(ec)), yaml.Parser()); err != nil {
+			return nil, fmt.Errorf("failed to load config from %s: %w", configEnvVar, err)
 		}
+		sources = append(sources, configEnvVar+" environment variable")
 	}
 
 	if err := k.Unmarshal("", c); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -56,20 +56,29 @@ func NewConfig() *Config {
 	return &Config{}
 }
 
-// Load loads the configuration from the config file
+// Load loads the configuration and returns the sources that contributed to it,
+// in load order (later values override earlier ones).
 //
-// Configuration is loaded in the following order (later values override earlier ones):
-// 1. Default values
-// 2. Config files from:
+// If path is non-empty it is used as the sole config file and must exist (a
+// missing file is an error). An explicit --config file is authoritative: the
+// default search locations and the WOL_CONFIG environment variable are ignored.
+//
+// If path is empty, the default locations are searched and any that are missing
+// are skipped, with WOL_CONFIG layered on top as the highest-precedence source:
 //   - /etc/wol/config.yaml
 //   - ~/.wol/config.yaml
 //   - ./config.yaml
 //
-// 3. Environment variable `WOL_CONFIG` containing full YAML config
-func (c *Config) Load() error {
+// In all cases the built-in defaults are the lowest-priority layer.
+func (c *Config) Load(path string) ([]string, error) {
+	// An explicit config file replaces the default search locations and must exist.
+	if path != "" {
+		return c.load([]string{path}, true)
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 
 	// Order here matters as later values will override earlier ones
@@ -79,20 +88,27 @@ func (c *Config) Load() error {
 		filepath.Join(".", configFilename),
 	}
 
-	return c.load(paths)
+	return c.load(paths, false)
 }
 
 // load reads configuration into c from the given file paths (in precedence order,
-// later overriding earlier) layered on top of the defaults, then applies the
-// WOL_CONFIG environment variable override.
+// later overriding earlier) layered on top of the defaults. When explicit is
+// false it then layers the WOL_CONFIG environment variable on top. It returns the
+// sources that actually contributed, in load order, so callers can report which
+// configuration was used.
+//
+// explicit selects the behavior for an explicit --config file: the file must
+// exist (a missing file is an error) and it is used on its own — WOL_CONFIG is
+// ignored. With auto-discovery (explicit false) missing files are skipped and
+// WOL_CONFIG is layered on top.
 //
 // It uses a fresh koanf instance per call so repeated loads don't accumulate
 // state, and takes its search paths as an argument so tests can point it at
 // temporary files instead of the real /etc/wol or ~/.wol.
-func (c *Config) load(paths []string) error {
+func (c *Config) load(paths []string, explicit bool) ([]string, error) {
 	k := koanf.New(koanfDelimiter)
 
-	// Load defaults first
+	// Defaults are the lowest-priority layer.
 	defaults := &Config{
 		Server: Server{
 			Listen: ":7777",
@@ -102,27 +118,40 @@ func (c *Config) load(paths []string) error {
 		},
 	}
 	if err := k.Load(structs.Provider(defaults, koanfTag), nil); err != nil {
-		return fmt.Errorf("failed to load defaults: %w", err)
+		return nil, fmt.Errorf("failed to load defaults: %w", err)
 	}
 
+	var sources []string
 	for _, path := range paths {
 		err := k.Load(file.Provider(path), yaml.Parser())
+		if err != nil {
+			if os.IsNotExist(err) {
+				// A missing explicit file is an error; a missing search-path
+				// location is simply skipped.
+				if explicit {
+					return nil, fmt.Errorf("config file %q does not exist", path)
+				}
+				continue
+			}
+			return nil, fmt.Errorf("failed to load config file %q: %w", path, err)
+		}
+		sources = append(sources, path)
+	}
 
-		// Ignore error if file does not exist
-		if err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to load config file: %w", err)
+	// An explicit --config file is authoritative and used on its own; WOL_CONFIG
+	// only applies when discovering configuration automatically.
+	if !explicit {
+		if ec := os.Getenv(configEnvVar); ec != "" {
+			if err := k.Load(rawbytes.Provider([]byte(ec)), yaml.Parser()); err != nil {
+				return nil, fmt.Errorf("failed to load config from %s: %w", configEnvVar, err)
+			}
+			sources = append(sources, configEnvVar+" environment variable")
 		}
 	}
 
-	// Load from `WOL_CONFIG` environment variable if set
-	ec := []byte(os.Getenv(configEnvVar))
-	if err := k.Load(rawbytes.Provider(ec), yaml.Parser()); err != nil {
-		return fmt.Errorf("failed to load config from %s: %w", configEnvVar, err)
-	}
-
 	if err := k.Unmarshal("", c); err != nil {
-		return fmt.Errorf("failed to unmarshal config: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	return nil
+	return sources, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,11 +21,14 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv(configEnvVar, "")
 
 	c := NewConfig()
-	require.NoError(t, c.load(nil))
+	sources, err := c.load(nil, false)
+	require.NoError(t, err)
 
 	assert.Equal(t, ":7777", c.Server.Listen)
 	assert.False(t, c.Ping.Privileged)
 	assert.Empty(t, c.Machines)
+	// Defaults alone are not a config "source".
+	assert.Empty(t, sources)
 }
 
 func TestLoadFilePrecedence(t *testing.T) {
@@ -49,7 +52,8 @@ machines:
 `)
 
 	c := NewConfig()
-	require.NoError(t, c.load([]string{lower, higher}))
+	sources, err := c.load([]string{lower, higher}, false)
+	require.NoError(t, err)
 
 	// Later file overrides the listen address...
 	assert.Equal(t, ":2222", c.Server.Listen)
@@ -59,6 +63,8 @@ machines:
 	// machines list wins entirely.
 	require.Len(t, c.Machines, 1)
 	assert.Equal(t, "beta", c.Machines[0].Name)
+	// Both files are reported as sources, in load order.
+	assert.Equal(t, []string{lower, higher}, sources)
 }
 
 func TestLoadWOLConfigOverride(t *testing.T) {
@@ -72,10 +78,37 @@ server:
 `)
 
 	c := NewConfig()
-	require.NoError(t, c.load([]string{file}))
+	sources, err := c.load([]string{file}, false)
+	require.NoError(t, err)
 
-	// WOL_CONFIG overrides values from config files.
+	// In search mode WOL_CONFIG is layered on top, so it overrides config files.
 	assert.Equal(t, ":9999", c.Server.Listen)
+	assert.Equal(t, []string{file, configEnvVar + " environment variable"}, sources)
+}
+
+func TestLoadExplicitIgnoresEnv(t *testing.T) {
+	// File sets listen and omits ping; env sets both.
+	file := writeConfig(t, `
+server:
+  listen: ":1234"
+`)
+	t.Setenv(configEnvVar, `
+server:
+  listen: ":9999"
+ping:
+  privileged: true
+`)
+
+	c := NewConfig()
+	sources, err := c.load([]string{file}, true)
+	require.NoError(t, err)
+
+	// An explicit file is used on its own: WOL_CONFIG is ignored entirely, so the
+	// file's value wins and a key the file omits falls back to the default.
+	assert.Equal(t, ":1234", c.Server.Listen)
+	assert.False(t, c.Ping.Privileged)
+	// Only the file is reported as a source.
+	assert.Equal(t, []string{file}, sources)
 }
 
 func TestLoadMissingFilesIgnored(t *testing.T) {
@@ -84,9 +117,23 @@ func TestLoadMissingFilesIgnored(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
 
 	c := NewConfig()
-	// Missing files are skipped rather than failing the load.
-	require.NoError(t, c.load([]string{missing}))
+	// Missing search-path files are skipped rather than failing the load.
+	sources, err := c.load([]string{missing}, false)
+	require.NoError(t, err)
 	assert.Equal(t, ":7777", c.Server.Listen)
+	assert.Empty(t, sources)
+}
+
+func TestLoadRequiredMissingErrors(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	c := NewConfig()
+	// An explicit (required) file that is missing is an error.
+	_, err := c.load([]string{missing}, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
 }
 
 func TestLoadMalformedYAML(t *testing.T) {
@@ -95,7 +142,8 @@ func TestLoadMalformedYAML(t *testing.T) {
 	bad := writeConfig(t, "machines: [unterminated\n")
 
 	c := NewConfig()
-	require.Error(t, c.load([]string{bad}))
+	_, err := c.load([]string{bad}, false)
+	require.Error(t, err)
 }
 
 func TestLoadDoesNotShareState(t *testing.T) {
@@ -108,13 +156,41 @@ machines:
 `)
 
 	first := NewConfig()
-	require.NoError(t, first.load([]string{withMachine}))
+	_, err := first.load([]string{withMachine}, false)
+	require.NoError(t, err)
 	require.Len(t, first.Machines, 1)
 
 	// A second load with no files must not inherit the first load's machines.
 	// Guards against regressing to a shared package-global koanf instance.
 	second := NewConfig()
-	require.NoError(t, second.load(nil))
+	_, err = second.load(nil, false)
+	require.NoError(t, err)
 	assert.Empty(t, second.Machines)
 	assert.Equal(t, ":7777", second.Server.Listen)
+}
+
+func TestLoadExplicitPath(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	// A non-empty path is used as-is, so this stays hermetic (no $HOME / /etc).
+	file := writeConfig(t, `
+server:
+  listen: ":4242"
+`)
+
+	c := NewConfig()
+	sources, err := c.Load(file)
+	require.NoError(t, err)
+	assert.Equal(t, ":4242", c.Server.Listen)
+	assert.Equal(t, []string{file}, sources)
+}
+
+func TestLoadExplicitMissing(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	missing := filepath.Join(t.TempDir(), "nope.yaml")
+
+	c := NewConfig()
+	_, err := c.Load(missing)
+	require.Error(t, err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,10 +179,10 @@ server:
 `)
 
 	c := NewConfig()
-	sources, err := c.Load(file)
+	err := c.Load(file)
 	require.NoError(t, err)
 	assert.Equal(t, ":4242", c.Server.Listen)
-	assert.Equal(t, []string{file}, sources)
+	assert.Equal(t, []string{file}, c.Sources())
 }
 
 func TestLoadExplicitMissing(t *testing.T) {
@@ -191,6 +191,6 @@ func TestLoadExplicitMissing(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "nope.yaml")
 
 	c := NewConfig()
-	_, err := c.Load(missing)
+	err := c.Load(missing)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Adds a persistent `-c`/`--config` flag so wol can be pointed at an explicit config file — handy for systemd units (`ExecStart=wol serve --config /etc/wol/config.yaml`).

## Behavior
- **Persistent `-c`/`--config` flag** on the root command (applies to all subcommands).
- **An explicit `--config` file is the sole, authoritative source**: it must exist (wol exits with an error if it doesn't), and both the default search locations and `WOL_CONFIG` are ignored — "use exactly this file". Built-in defaults still apply underneath it.
- **Without `-c`, precedence is unchanged**: defaults → search files (`/etc/wol`, `~/.wol`, `./`) → `WOL_CONFIG`.
- **`serve` logs the resolved config source at startup** (e.g. `Loaded config from /etc/wol/config.yaml`, or a defaults notice). One-shot commands stay quiet, matching common CLI/daemon conventions.

## Implementation
- `config.Load(path string) error` takes the explicit path; the loaded `Config` records which inputs contributed, exposed via `Config.Sources()`. The internal `load` layers defaults → files → `WOL_CONFIG` (search mode only).
- `cmd/root.go` registers the flag and loads config in `PersistentPreRunE`; `cmd/serve.go` logs `cfg.Sources()` at startup.

## Tests
- Updated the loader tests and added coverage for: explicit-missing errors, explicit-path success, and that an explicit file ignores `WOL_CONFIG`.

Resolves #19.

Part of ME-11