### PR TITLE
fix: don't log on each status poll for unresolvable hosts

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -163,7 +163,7 @@ func (s *server) machineStatus(machine config.Machine) (string, error) {
 
 	reachable, err := s.pinger.Reachable(*machine.IP)
 	if err != nil {
-		fmt.Println(err)
+		// Don't log here; machinesStatus logs the error once per machine.
 		return "unknown", err
 	}
 	if reachable {
@@ -261,7 +261,9 @@ func newProbingPinger(privileged bool) *probingPinger {
 func (p *probingPinger) Reachable(addr string) (bool, error) {
 	pinger, err := probing.NewPinger(addr)
 	if err != nil {
-		return false, fmt.Errorf("error creating pinger: %w", err)
+		// addr couldn't be resolved (e.g. an off machine's hostname). Treat as
+		// unreachable instead of erroring, so the status poll doesn't log it each tick.
+		return false, nil
 	}
 	// Set privileged mode based on config
 	pinger.SetPrivileged(p.privileged)


### PR DESCRIPTION
## Problem

When a configured machine's hostname can't be resolved (for example it's powered off and its mDNS/`.local` name is gone), `probing.NewPinger` returns a DNS error. The status poller runs every 5 seconds while a browser holds the `/status` stream open, so one offline machine spams the log. It gets logged twice per tick:

```
error creating pinger: lookup dance.local on 10.255.255.254:53: no such host
2026/06/14 00:57:46 Error getting status for machine geek: error creating pinger: lookup dance.local on 10.255.255.254:53: no such host
```

## Fix

`NewPinger` only resolves the address, so a failure means there's no address to ping. For the status poll that just means the machine is unreachable, not that something went wrong.

- `Reachable` now returns `false, nil` on a `NewPinger` failure, so the machine shows as offline instead of erroring every tick.
- Removed a leftover `fmt.Println(err)` in `machineStatus` that double-logged real errors. `machinesStatus` already logs them once.

## Verification

Reproduced with a config pointing at an unresolvable host (`ip: "dance.local"`) and driving `/status` for several ticks. After the fix the log stays quiet and the machine reports offline. `go build`, `go vet`, `go test ./...`, and `gofmt` are clean.

Supersedes #20 by @lordwelch, which was opened before `isAddressReachable` was refactored into the `Reachable` method.

Closes #20