### PR TITLE
feat: add scheduled wake-ups via cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ network. Features both CLI commands and a web interface.
 - Configurable broadcast address and port, with per-machine overrides
 - List configured machines
 - Web interface for easy wake-up
+- Scheduled wake-ups on a cron schedule
 - Docker support
 
 ## Installation
@@ -150,6 +151,11 @@ broadcast:
 
 ping:
   privileged: false # Optional, set to true if you need privileged ping
+
+schedules: # Optional, cron wake-ups run by `wol serve`
+  - name: weekend-backup # Optional label, shown in logs
+    machine: server # Must match a machine name above
+    cron: "0 2 * * 6" # Saturday 02:00
 ```
 
 ### Broadcast address and port
@@ -172,6 +178,28 @@ You can set the broadcast target in three ways:
 
 When more than one is set, the order of precedence is: CLI flag, then per-machine
 config, then global config, then the built-in default of `255.255.255.255:9`.
+
+### Scheduled wake-ups
+
+The optional `schedules` section makes `wol serve` wake machines automatically on
+a cron schedule. Omit it (or leave it empty) and scheduling is disabled — `serve`
+behaves exactly as before.
+
+Each schedule has:
+
+- `machine` (required) — the name of a machine defined under `machines`.
+- `cron` (required) — when to wake it. Standard five-field cron expressions
+  (`minute hour day-of-month month day-of-week`) are supported, as are the
+  `@hourly`, `@daily`, `@weekly`, `@monthly` and `@every 1h30m` descriptors.
+- `name` (optional) — a label used in log output; defaults to the machine name.
+
+Cron expressions are evaluated in the **server's local time**. When running in a
+container, set the `TZ` environment variable (e.g. `TZ=America/New_York`) to
+control the timezone.
+
+Schedules are validated when `serve` starts: a schedule that references an unknown
+machine or carries an invalid cron expression makes `wol serve` exit with an error,
+so misconfiguration is caught immediately rather than silently never firing.
 
 ## Usage
 

--- a/cmd/schedule.go
+++ b/cmd/schedule.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/robfig/cron/v3"
+	"github.com/trugamr/wol/config"
+)
+
+// resolvedSchedule is a config.Schedule that has been validated against the
+// configured machines: its target MAC and broadcast address are resolved and its
+// cron expression is parsed. label is what gets logged when the job runs.
+type resolvedSchedule struct {
+	label    string
+	mac      net.HardwareAddr
+	addr     string
+	schedule cron.Schedule
+}
+
+// resolveSchedules validates each schedule in cfg and returns the resolved
+// schedules ready to register with cron. It fails fast: the first schedule that
+// references an unknown machine, has an unparseable MAC, or carries an invalid
+// cron expression aborts with an error, so misconfiguration is surfaced at
+// startup rather than silently never firing. The broadcast target is resolved
+// per machine (the same precedence the send and web-wake paths use), so a
+// scheduled wake honors any per-machine broadcast override.
+func resolveSchedules(cfg *config.Config) ([]resolvedSchedule, error) {
+	resolved := make([]resolvedSchedule, 0, len(cfg.Schedules))
+	for _, s := range cfg.Schedules {
+		label := s.Name
+		if label == "" {
+			label = s.Machine
+		}
+
+		machine, err := cfg.MachineByName(s.Machine)
+		if err != nil {
+			return nil, fmt.Errorf("schedule %q: %w", label, err)
+		}
+
+		mac, err := machine.HardwareAddr()
+		if err != nil {
+			return nil, fmt.Errorf("schedule %q: %w", label, err)
+		}
+
+		schedule, err := cron.ParseStandard(s.Cron)
+		if err != nil {
+			return nil, fmt.Errorf("schedule %q: invalid cron expression %q: %w", label, s.Cron, err)
+		}
+
+		resolved = append(resolved, resolvedSchedule{
+			label:    label,
+			mac:      mac,
+			addr:     cfg.BroadcastFor(machine).Addr(),
+			schedule: schedule,
+		})
+	}
+	return resolved, nil
+}
+
+// wakeJob returns the function cron runs when a schedule fires: it logs the
+// trigger and wakes the machine, logging any error. It is split out so the job
+// body can be tested without waiting on cron timing.
+func wakeJob(wake waker, rs resolvedSchedule) func() {
+	return func() {
+		log.Printf("Triggered scheduled wake for %s", rs.label)
+		if err := wake(rs.mac, rs.addr); err != nil {
+			log.Printf("Error sending scheduled magic packet for %s: %v", rs.label, err)
+		}
+	}
+}
+
+// scheduler runs cron wake-ups for the duration of the serve command.
+type scheduler struct {
+	cron *cron.Cron
+}
+
+// newScheduler resolves and registers every schedule in cfg, returning an error
+// if any references an unknown machine, has an unparseable MAC, or has an invalid
+// cron expression. The returned scheduler is not started yet; call start to begin
+// firing jobs.
+func newScheduler(cfg *config.Config, wake waker) (*scheduler, error) {
+	resolved, err := resolveSchedules(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	c := cron.New()
+	for _, rs := range resolved {
+		// rs.schedule is already parsed, so register it directly rather than
+		// re-parsing the spec string via AddFunc.
+		c.Schedule(rs.schedule, cron.FuncJob(wakeJob(wake, rs)))
+	}
+
+	return &scheduler{cron: c}, nil
+}
+
+// start begins running the scheduled jobs in the background.
+//
+// There is intentionally no stop method: serve blocks on http.ListenAndServe
+// for the life of the process, so the scheduler simply dies with it. Add a stop
+// method (wrapping s.cron.Stop) when serve grows graceful shutdown.
+func (s *scheduler) start() {
+	s.cron.Start()
+}

--- a/cmd/schedule_test.go
+++ b/cmd/schedule_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trugamr/wol/config"
+)
+
+func TestResolveSchedules(t *testing.T) {
+	machines := []config.Machine{
+		{Name: "nas", Mac: "01:02:03:04:05:06"},
+		{Name: "badmac", Mac: "not-a-mac"},
+	}
+	newCfg := func(schedules ...config.Schedule) *config.Config {
+		return &config.Config{
+			Broadcast: config.Broadcast{Address: "255.255.255.255", Port: 9},
+			Machines:  machines,
+			Schedules: schedules,
+		}
+	}
+
+	t.Run("valid schedules resolve to MAC and broadcast", func(t *testing.T) {
+		resolved, err := resolveSchedules(newCfg(
+			config.Schedule{Name: "weekend-backup", Machine: "nas", Cron: "0 2 * * 6"},
+			config.Schedule{Machine: "nas", Cron: "@daily"},
+		))
+		require.NoError(t, err)
+		require.Len(t, resolved, 2)
+
+		want, err := net.ParseMAC("01:02:03:04:05:06")
+		require.NoError(t, err)
+
+		assert.Equal(t, "weekend-backup", resolved[0].label)
+		assert.Equal(t, want, resolved[0].mac)
+		assert.Equal(t, "255.255.255.255:9", resolved[0].addr)
+		assert.NotNil(t, resolved[0].schedule)
+
+		// An omitted name falls back to the machine name in the label.
+		assert.Equal(t, "nas", resolved[1].label)
+	})
+
+	t.Run("per-machine broadcast override is honored", func(t *testing.T) {
+		cfg := &config.Config{
+			Broadcast: config.Broadcast{Address: "255.255.255.255", Port: 9},
+			Machines: []config.Machine{
+				{Name: "nas", Mac: "01:02:03:04:05:06", Broadcast: &config.Broadcast{Address: "192.168.1.255"}},
+			},
+			Schedules: []config.Schedule{{Machine: "nas", Cron: "@daily"}},
+		}
+		resolved, err := resolveSchedules(cfg)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		// Address overridden per machine, port inherited from the global default.
+		assert.Equal(t, "192.168.1.255:9", resolved[0].addr)
+	})
+
+	t.Run("empty input yields no schedules", func(t *testing.T) {
+		resolved, err := resolveSchedules(newCfg())
+		require.NoError(t, err)
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("unknown machine fails fast", func(t *testing.T) {
+		_, err := resolveSchedules(newCfg(
+			config.Schedule{Name: "ghost-wake", Machine: "ghost", Cron: "@daily"},
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ghost-wake")
+		assert.Contains(t, err.Error(), "ghost")
+	})
+
+	t.Run("invalid cron fails fast", func(t *testing.T) {
+		_, err := resolveSchedules(newCfg(
+			config.Schedule{Name: "bad-cron", Machine: "nas", Cron: "not a cron"},
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad-cron")
+		assert.Contains(t, err.Error(), "not a cron")
+	})
+
+	t.Run("unparseable machine MAC fails fast", func(t *testing.T) {
+		_, err := resolveSchedules(newCfg(
+			config.Schedule{Machine: "badmac", Cron: "@daily"},
+		))
+		require.Error(t, err)
+	})
+}
+
+func TestWakeJob(t *testing.T) {
+	want, err := net.ParseMAC("01:02:03:04:05:06")
+	require.NoError(t, err)
+
+	var gotMac net.HardwareAddr
+	var gotAddr string
+	wake := func(mac net.HardwareAddr, addr string) error {
+		gotMac = mac
+		gotAddr = addr
+		return nil
+	}
+
+	wakeJob(wake, resolvedSchedule{label: "nas", mac: want, addr: "192.168.1.255:9"})()
+
+	assert.Equal(t, want, gotMac)
+	assert.Equal(t, "192.168.1.255:9", gotAddr)
+}
+
+func TestNewSchedulerInvalidConfig(t *testing.T) {
+	cfg := &config.Config{
+		Machines:  []config.Machine{{Name: "nas", Mac: "01:02:03:04:05:06"}},
+		Schedules: []config.Schedule{{Name: "ghost-wake", Machine: "ghost", Cron: "@daily"}},
+	}
+	_, err := newScheduler(cfg, func(net.HardwareAddr, string) error { return nil })
+	require.Error(t, err)
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -111,13 +111,26 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Group schedules by their resolved machine name so the template can show a
+	// per-machine indicator. Keyed by the canonical machine name (what the card
+	// renders) so lookup matches regardless of how the schedule spelled it.
+	schedulesByMachine := make(map[string][]config.Schedule)
+	for _, sch := range s.cfg.Schedules {
+		m, err := s.cfg.MachineByName(sch.Machine)
+		if err != nil {
+			continue // unknown machine; already rejected at serve startup
+		}
+		schedulesByMachine[m.Name] = append(schedulesByMachine[m.Name], sch)
+	}
+
 	// Execute the template
 	data := map[string]interface{}{
-		"Machines":     s.cfg.Machines,
-		"Version":      version,
-		"Commit":       commit,
-		"Date":         date,
-		"FlashMessage": consumeFlashMessage(w, r), // Get flash message from cookie
+		"Machines":           s.cfg.Machines,
+		"SchedulesByMachine": schedulesByMachine,
+		"Version":            version,
+		"Commit":             commit,
+		"Date":               date,
+		"FlashMessage":       consumeFlashMessage(w, r), // Get flash message from cookie
 	}
 	err = index.Execute(w, data)
 	if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -41,6 +41,15 @@ var serveCmd = &cobra.Command{
 			log.Print("No config file found; using built-in defaults")
 		}
 
+		// Start cron wake-ups when configured; a misconfigured schedule
+		// (unknown machine or invalid cron) aborts serve before it listens.
+		if len(cfg.Schedules) > 0 {
+			sched, err := newScheduler(cfg, broadcastWake)
+			cobra.CheckErr(err)
+			sched.start()
+			log.Printf("Started %d scheduled wake-up(s)", len(cfg.Schedules))
+		}
+
 		handler := newServer(cfg, newProbingPinger(cfg.Ping.Privileged), broadcastWake).routes()
 
 		log.Printf("Listening on %s", cfg.Server.Listen)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -37,6 +37,52 @@ func TestHandleIndexRendersMachines(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "alpha")
 }
 
+func TestHandleIndexShowsScheduleChip(t *testing.T) {
+	cfg := &config.Config{
+		Machines: []config.Machine{
+			{Name: "scheduled", Mac: "01:02:03:04:05:06"},
+			{Name: "plain", Mac: "0a:0b:0c:0d:0e:0f"},
+		},
+		Schedules: []config.Schedule{{Machine: "scheduled", Cron: "0 2 * * 6"}},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	newServer(cfg, nil, nil).routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	// The scheduled machine renders a chip with its cron expression...
+	assert.Contains(t, body, "0 2 * * 6")
+	// ...and there is exactly one chip (the unscheduled machine has none, and a
+	// single schedule produces no "+N" overflow pill). Match the rendered class
+	// attribute, not the bare name, which also appears in the <style> block.
+	assert.Equal(t, 1, strings.Count(body, `class="machine__schedule"`))
+	assert.NotContains(t, body, `class="machine__schedule machine__schedule--more"`)
+}
+
+func TestHandleIndexCollapsesExtraSchedules(t *testing.T) {
+	cfg := &config.Config{
+		Machines: []config.Machine{{Name: "media-server", Mac: "01:02:03:04:05:06"}},
+		Schedules: []config.Schedule{
+			{Machine: "media-server", Cron: "@daily"},
+			{Machine: "media-server", Cron: "@every 1m"},
+			{Machine: "media-server", Cron: "0 18 * * 1-5"},
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	newServer(cfg, nil, nil).routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	// Only the first schedule is shown as a visible chip; the rest collapse into
+	// a "+2" overflow pill (their crons live in its title for hover).
+	assert.Equal(t, 1, strings.Count(body, `class="machine__schedule"`))
+	assert.Contains(t, body, `class="machine__schedule machine__schedule--more"`)
+	assert.Contains(t, body, "@daily")
+	assert.Contains(t, body, ">+2<")
+}
+
 func TestHandleWakeSuccess(t *testing.T) {
 	const macStr = "01:02:03:04:05:06"
 	cfg := &config.Config{

--- a/cmd/templates/index.html
+++ b/cmd/templates/index.html
@@ -215,6 +215,11 @@
         flex-direction: column;
         gap: 0.35rem;
         min-width: 0;
+        /* Fill the card's height (cards in a row share the tallest one's height)
+           so the name/MAC stay anchored to the top instead of floating in the
+           vertical center when a sibling card is taller for its schedule chip.
+           The Wake button keeps the parent's center alignment. */
+        align-self: stretch;
       }
 
       .machine__name {
@@ -233,6 +238,50 @@
         font-size: 0.82rem;
         color: var(--text-muted);
         letter-spacing: 0.02em;
+      }
+
+      /* Schedule chips — shown only for machines with a cron wake-up. One chip
+         per schedule; they wrap if a machine has several. */
+      .machine__schedules {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        margin-top: 0.15rem;
+      }
+
+      .machine__schedule {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        max-width: 100%;
+        padding: 0.16rem 0.5rem;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 0.72rem;
+        font-weight: 600;
+        line-height: 1.4;
+      }
+
+      .machine__schedule svg {
+        flex: none;
+        width: 12px;
+        height: 12px;
+      }
+
+      .machine__schedule .mono {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      /* The "+N" pill collapsing any schedules beyond the first; full list in
+         its title. Muted/outlined so it reads as a count, not another cron. */
+      .machine__schedule--more {
+        background: transparent;
+        color: var(--text-muted);
+        border: 1px dashed var(--border);
+        cursor: default;
       }
 
       /* vertical-align:middle aligns the dot to the text's optical center (its x-height
@@ -427,6 +476,38 @@
                 ><span class="machine__name">{{.Name}}</span>
               </div>
               <span class="machine__mac mono">{{.Mac}}</span>
+              {{$scheds := index $.SchedulesByMachine .Name}}
+              {{if $scheds}}
+              {{$first := index $scheds 0}}
+              <div class="machine__schedules">
+                <span
+                  class="machine__schedule"
+                  {{if $first.Name}}title="{{$first.Name}}"{{end}}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <path d="M12 7v5l3 2" />
+                  </svg>
+                  <span class="mono">{{$first.Cron}}</span>
+                </span>
+                {{if gt (len $scheds) 1}}
+                {{$rest := slice $scheds 1}}
+                <span
+                  class="machine__schedule machine__schedule--more"
+                  title="{{range $i, $r := $rest}}{{if $i}}&#10;{{end}}{{if $r.Name}}{{$r.Name}}: {{end}}{{$r.Cron}}{{end}}"
+                  >+{{len $rest}}</span
+                >
+                {{end}}
+              </div>
+              {{end}}
             </div>
             <form class="wake-form" action="/wake" method="POST">
               <input type="hidden" name="name" value="{{.Name}}" />

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,3 +19,9 @@ broadcast:
 # Check: https://github.com/prometheus-community/pro-bing?tab=readme-ov-file#supported-operating-systems
 ping:
   privileged: false
+# Optional cron wake-ups, run by the `serve` command. Each schedule wakes a
+# machine (by name) on a cron schedule evaluated in the server's local time.
+# schedules:
+#   - name: weekend-backup # Optional label, shown in logs
+#     machine: desktop     # Must match a machine name above
+#     cron: "0 2 * * 6"    # Saturday 02:00; also supports @daily, @every 1h, etc.

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,19 @@ type Ping struct {
 	Privileged bool `koanf:"privileged"`
 }
 
+// Schedule represents an automatic cron wake-up for a configured machine.
+type Schedule struct {
+	// Name is an optional label used in log output. When empty the machine
+	// name is used instead.
+	Name string `koanf:"name"`
+	// Machine is the name of a configured machine to wake (required).
+	Machine string `koanf:"machine"`
+	// Cron is the schedule expression, e.g. "0 2 * * 6" (required). It is
+	// evaluated in the server's local time and supports the standard five
+	// fields as well as descriptors like @daily and @every.
+	Cron string `koanf:"cron"`
+}
+
 // Config represents the configuration for the application
 type Config struct {
 	// Machines represents the list of machines to wake up
@@ -86,6 +99,9 @@ type Config struct {
 	Ping Ping `koanf:"ping"`
 	// Broadcast represents the default broadcast target for magic packets.
 	Broadcast Broadcast `koanf:"broadcast"`
+	// Schedules represents optional cron wake-ups run by the serve command.
+	// When empty, scheduling is disabled.
+	Schedules []Schedule `koanf:"schedules"`
 
 	// sources records which inputs contributed to the loaded config, in load
 	// order. It is unexported so koanf's reflection-based providers ignore it.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -323,3 +323,44 @@ func TestLoadExplicitMissing(t *testing.T) {
 	err := c.Load(missing)
 	require.Error(t, err)
 }
+
+func TestLoadSchedules(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	file := writeConfig(t, `
+machines:
+  - name: nas
+    mac: "01:02:03:04:05:06"
+schedules:
+  - name: weekend-backup
+    machine: nas
+    cron: "0 2 * * 6"
+  - machine: nas
+    cron: "@daily"
+`)
+
+	c := NewConfig()
+	_, err := c.load([]string{file}, true)
+	require.NoError(t, err)
+
+	require.Len(t, c.Schedules, 2)
+	assert.Equal(t, Schedule{Name: "weekend-backup", Machine: "nas", Cron: "0 2 * * 6"}, c.Schedules[0])
+	// The optional name may be omitted.
+	assert.Equal(t, Schedule{Machine: "nas", Cron: "@daily"}, c.Schedules[1])
+}
+
+func TestLoadSchedulesAbsent(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	// A config without a schedules section leaves Schedules empty (disabled).
+	file := writeConfig(t, `
+machines:
+  - name: nas
+    mac: "01:02:03:04:05:06"
+`)
+
+	c := NewConfig()
+	_, err := c.load([]string{file}, true)
+	require.NoError(t, err)
+	assert.Empty(t, c.Schedules)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/knadh/koanf/providers/structs v1.0.0
 	github.com/knadh/koanf/v2 v2.3.5
 	github.com/prometheus-community/pro-bing v0.9.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus-community/pro-bing v0.9.0 h1:M/zt1lL7cmbK+wm40RPS4waaiAN2EcYEeD4Xt0Lv4x0=
 github.com/prometheus-community/pro-bing v0.9.0/go.mod h1:IBeW2ScY7sAWv4mYjH0xDDigqfe7kXeVxNdbNKdBHWY=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=


### PR DESCRIPTION
Adds an optional top-level `schedules` section so `wol serve` can wake machines on a cron schedule (e.g. wake a NAS before a weekly backup).

## Behavior
- New top-level `schedules` list. Each entry has a `machine` (a name from `machines`), a `cron` expression, and an optional `name` label used in logs.
- `serve` starts a cron scheduler (robfig/cron) only when schedules are set; with none, behavior is unchanged.
- Schedules are validated at startup: an unknown machine name or an invalid cron expression makes `serve` exit with a clear error, so a typo cannot silently fail to fire.
- Cron uses the standard five fields plus descriptors like `@daily` and `@every 1h`, evaluated in the server's local time.

## Example
```yaml
machines:
  - name: nas
    mac: "AA:BB:CC:DD:EE:FF"

schedules:
  - name: weekend-backup
    machine: nas
    cron: "0 2 * * 6"
```

## Tests
- Config unmarshalling for the `schedules` section.
- Schedule resolution (valid, unknown machine, invalid cron, empty input) and the wake job.
- `go build`, `go vet`, `go test ./...` pass.

Supersedes #11 (thanks @JordanWre for the original).

Resolves #3.

Part of ME-13