### PR TITLE
feat: configurable broadcast address and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ network. Features both CLI commands and a web interface.
 
 - Send WOL magic packets via CLI or web interface
 - Configure multiple machines with names for easy access
+- Configurable broadcast address and port, with per-machine overrides
 - List configured machines
 - Web interface for easy wake-up
 - Docker support
@@ -125,13 +126,43 @@ machines:
   - name: server
     mac: "AA:BB:CC:DD:EE:FF"
     ip: "server.local"
+    # Optional per-machine broadcast override, e.g. when this machine is on a
+    # different subnet/VLAN. Unset fields inherit the global broadcast below.
+    broadcast:
+      address: "192.168.20.255"
 
 server:
   listen: ":7777" # Optional, defaults to :7777
 
+# Optional. Where magic packets are sent; defaults to 255.255.255.255:9.
+broadcast:
+  address: "255.255.255.255"
+  port: 9
+
 ping:
   privileged: false # Optional, set to true if you need privileged ping
 ```
+
+### Broadcast address and port
+
+By default, magic packets are sent to the broadcast address `255.255.255.255` on
+port `9`. On a host with more than one network interface (for example WSL2, or a
+host with Docker bridges), the OS may send the packet out the wrong interface, so
+the device never receives it.
+
+If that happens, set the broadcast address of your device's own subnet. For a
+device at `192.168.1.100/24` that address is `192.168.1.255`. The packet is then
+routed out the correct interface.
+
+You can set the broadcast target in three ways:
+
+- Globally, under the `broadcast` key.
+- Per machine, under a machine's own `broadcast` key. This is useful when machines
+  are on different subnets. Any field you leave out falls back to the global value.
+- For a single send, with the `--broadcast` and `--port` flags.
+
+When more than one is set, the order of precedence is: CLI flag, then per-machine
+config, then global config, then the built-in default of `255.255.255.255:9`.
 
 ## Usage
 
@@ -146,6 +177,10 @@ wol send --name desktop
 
 # Wake up a machine by MAC address
 wol send --mac "00:11:22:33:44:55"
+
+# Override the broadcast address and port for a single send
+# (for example, to reach a device on a specific subnet)
+wol send --mac "00:11:22:33:44:55" --broadcast 192.168.1.255 --port 9
 
 # Start the web interface
 wol serve

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/trugamr/wol/config"
 	"github.com/trugamr/wol/magicpacket"
 )
 
@@ -16,6 +14,8 @@ func init() {
 
 	sendCmd.Flags().StringP("mac", "m", "", "MAC address of the device to wake up")
 	sendCmd.Flags().StringP("name", "n", "", "Name of the device to wake up")
+	sendCmd.Flags().StringP("broadcast", "b", "", "Broadcast address to send the magic packet to (overrides config)")
+	sendCmd.Flags().IntP("port", "p", 0, "UDP port to send the magic packet to (overrides config)")
 }
 
 var sendCmd = &cobra.Command{
@@ -32,6 +32,9 @@ var sendCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var mac net.HardwareAddr
+		// Default to the global broadcast target; the --name path may refine it
+		// with the machine's per-machine override.
+		broadcast := cfg.Broadcast
 
 		// Retrieve mac address using one of the flags
 		switch true {
@@ -53,35 +56,43 @@ var sendCmd = &cobra.Command{
 			}
 
 			// Find machine with the specified name
-			mac, err = getMacByName(cfg.Machines, name)
+			machine, err := cfg.MachineByName(name)
 			if err != nil {
 				cobra.CheckErr(err)
 			}
+
+			mac, err = net.ParseMAC(machine.Mac)
+			if err != nil {
+				cobra.CheckErr(fmt.Errorf("failed to parse MAC address: %w", err))
+			}
+			broadcast = cfg.BroadcastFor(machine)
 		default:
 			log.Fatalf("mac address should come from either --mac or --name")
 		}
 
-		log.Printf("Sending magic packet to %s", mac)
+		// Command-line flags take precedence over config.
+		if cmd.Flags().Changed("broadcast") {
+			value, err := cmd.Flags().GetString("broadcast")
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+			broadcast.Address = value
+		}
+		if cmd.Flags().Changed("port") {
+			value, err := cmd.Flags().GetInt("port")
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+			broadcast.Port = value
+		}
+
+		addr := broadcast.Addr()
+		log.Printf("Sending magic packet to %s via %s", mac, addr)
 		mp := magicpacket.NewMagicPacket(mac)
-		if err := mp.Broadcast(); err != nil {
+		if err := mp.Broadcast(addr); err != nil {
 			cobra.CheckErr(err)
 		}
 
 		log.Printf("Magic packet sent")
 	},
-}
-
-// getMacByName returns the MAC address of the machine with the specified name
-func getMacByName(machines []config.Machine, name string) (net.HardwareAddr, error) {
-	for _, machine := range machines {
-		if strings.EqualFold(machine.Name, name) {
-			mac, err := net.ParseMAC(machine.Mac)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse MAC address: %w", err)
-			}
-			return mac, nil
-		}
-	}
-
-	return nil, fmt.Errorf("machine with name %q not found", name)
 }

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -61,9 +61,9 @@ var sendCmd = &cobra.Command{
 				cobra.CheckErr(err)
 			}
 
-			mac, err = net.ParseMAC(machine.Mac)
+			mac, err = machine.HardwareAddr()
 			if err != nil {
-				cobra.CheckErr(fmt.Errorf("failed to parse MAC address: %w", err))
+				cobra.CheckErr(err)
 			}
 			broadcast = cfg.BroadcastFor(machine)
 		default:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -143,9 +143,9 @@ func (s *server) handleWake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mac, err := net.ParseMAC(machine.Mac)
+	mac, err := machine.HardwareAddr()
 	if err != nil {
-		http.Error(w, fmt.Sprintf("failed to parse MAC address: %v", err), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -53,12 +53,13 @@ type Pinger interface {
 	Reachable(addr string) (bool, error)
 }
 
-// waker sends a wake-on-LAN magic packet to the given MAC address.
-type waker func(mac net.HardwareAddr) error
+// waker sends a wake-on-LAN magic packet to the given MAC address, broadcasting
+// to addr (a "host:port" target).
+type waker func(mac net.HardwareAddr, addr string) error
 
 // broadcastWake is the production waker: it broadcasts a real magic packet.
-func broadcastWake(mac net.HardwareAddr) error {
-	return magicpacket.NewMagicPacket(mac).Broadcast()
+func broadcastWake(mac net.HardwareAddr, addr string) error {
+	return magicpacket.NewMagicPacket(mac).Broadcast(addr)
 }
 
 // server holds the dependencies for the web handlers. Injecting them (rather
@@ -136,14 +137,21 @@ func consumeFlashMessage(w http.ResponseWriter, r *http.Request) string {
 
 func (s *server) handleWake(w http.ResponseWriter, r *http.Request) {
 	machineName := r.FormValue("name")
-	mac, err := getMacByName(s.cfg.Machines, machineName)
+	machine, err := s.cfg.MachineByName(machineName)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	log.Printf("Sending magic packet to %s", mac)
-	if err := s.wake(mac); err != nil {
+	mac, err := net.ParseMAC(machine.Mac)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to parse MAC address: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	addr := s.cfg.BroadcastFor(machine).Addr()
+	log.Printf("Sending magic packet to %s via %s", mac, addr)
+	if err := s.wake(mac, addr); err != nil {
 		log.Printf("Error sending magic packet: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -40,12 +40,23 @@ func TestHandleIndexRendersMachines(t *testing.T) {
 func TestHandleWakeSuccess(t *testing.T) {
 	const macStr = "01:02:03:04:05:06"
 	cfg := &config.Config{
-		Machines: []config.Machine{{Name: "alpha", Mac: macStr}},
+		// The machine overrides only the broadcast address, so the port should be
+		// inherited from the global default.
+		Broadcast: config.Broadcast{Address: "255.255.255.255", Port: 9},
+		Machines: []config.Machine{{
+			Name:      "alpha",
+			Mac:       macStr,
+			Broadcast: &config.Broadcast{Address: "192.168.1.255"},
+		}},
 	}
 
-	var gotMac net.HardwareAddr
-	wake := func(mac net.HardwareAddr) error {
+	var (
+		gotMac  net.HardwareAddr
+		gotAddr string
+	)
+	wake := func(mac net.HardwareAddr, addr string) error {
 		gotMac = mac
+		gotAddr = addr
 		return nil
 	}
 	req := httptest.NewRequest(http.MethodPost, "/wake", strings.NewReader("name=alpha"))
@@ -60,6 +71,10 @@ func TestHandleWakeSuccess(t *testing.T) {
 	want, err := net.ParseMAC(macStr)
 	require.NoError(t, err)
 	assert.Equal(t, want, gotMac)
+
+	// The per-machine broadcast override was resolved (address overridden, port
+	// inherited from the global default) and passed to the wake seam.
+	assert.Equal(t, "192.168.1.255:9", gotAddr)
 
 	// A flash message cookie naming the machine is set.
 	var flash *http.Cookie
@@ -78,7 +93,7 @@ func TestHandleWakeMachineNotFound(t *testing.T) {
 	}
 
 	called := false
-	wake := func(mac net.HardwareAddr) error {
+	wake := func(mac net.HardwareAddr, addr string) error {
 		called = true
 		return nil
 	}
@@ -118,35 +133,4 @@ func TestWriteMachinesStatusFrame(t *testing.T) {
 		"off":     "offline",
 		"unknown": "unknown",
 	}, statuses)
-}
-
-func TestGetMacByName(t *testing.T) {
-	machines := []config.Machine{
-		{Name: "alpha", Mac: "01:02:03:04:05:06"},
-		{Name: "badmac", Mac: "not-a-mac"},
-	}
-
-	tests := []struct {
-		name      string
-		lookup    string
-		wantMAC   string
-		wantError bool
-	}{
-		{name: "exact match", lookup: "alpha", wantMAC: "01:02:03:04:05:06"},
-		{name: "case-insensitive match", lookup: "ALPHA", wantMAC: "01:02:03:04:05:06"},
-		{name: "not found", lookup: "ghost", wantError: true},
-		{name: "invalid mac", lookup: "badmac", wantError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mac, err := getMacByName(machines, tt.lookup)
-			if tt.wantError {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantMAC, mac.String())
-		})
-	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,8 +3,19 @@ machines:
     mac: 00:00:00:00:00:01
   - name: laptop
     mac: 00:00:00:00:00:02
+    # Per-machine override: useful when this machine lives on a different
+    # subnet/VLAN. Unset fields (here, port) inherit the global broadcast below.
+    broadcast:
+      address: 192.168.1.255
 server:
   listen: 0.0.0.0:7777
+# Where magic packets are sent. Defaults to 255.255.255.255:9.
+# On a multi-homed host the limited broadcast 255.255.255.255 may leave the wrong
+# interface; use the subnet-directed broadcast (e.g. 192.168.1.255) of the network
+# your device is on so the packet is routed out the correct interface.
+broadcast:
+  address: 255.255.255.255
+  port: 9
 # Check: https://github.com/prometheus-community/pro-bing?tab=readme-ov-file#supported-operating-systems
 ping:
   privileged: false

--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
@@ -27,6 +30,29 @@ type Machine struct {
 	Mac string `koanf:"mac"`
 	// Hostname or IP address of the machine (optional)
 	IP *string `koanf:"ip"`
+	// Broadcast optionally overrides the global broadcast target for this
+	// machine. Zero-value fields inherit the global setting. This is what lets a
+	// machine on a different subnet/VLAN use its own directed broadcast address.
+	Broadcast *Broadcast `koanf:"broadcast"`
+}
+
+// Broadcast is the destination a magic packet is sent to. It is reused for the
+// global default and for per-machine overrides; on an override, a zero-value
+// field (empty Address or zero Port) inherits the global value.
+type Broadcast struct {
+	// Address is the broadcast address to send the magic packet to. Use the
+	// subnet-directed broadcast (e.g. 192.168.1.255) to reliably reach a device
+	// on a specific subnet from a multi-homed host, rather than the limited
+	// broadcast 255.255.255.255.
+	Address string `koanf:"address"`
+	// Port is the UDP port to send the magic packet to (typically 9, sometimes 7).
+	Port int `koanf:"port"`
+}
+
+// Addr returns the host:port string the magic packet is dialed to,
+// e.g. "192.168.1.255:9".
+func (b Broadcast) Addr() string {
+	return net.JoinHostPort(b.Address, strconv.Itoa(b.Port))
 }
 
 // Server represents the server configuration
@@ -49,6 +75,8 @@ type Config struct {
 	Server Server `koanf:"server"`
 	// Ping represents the ping configuration
 	Ping Ping `koanf:"ping"`
+	// Broadcast represents the default broadcast target for magic packets.
+	Broadcast Broadcast `koanf:"broadcast"`
 
 	// sources records which inputs contributed to the loaded config, in load
 	// order. It is unexported so koanf's reflection-based providers ignore it.
@@ -64,6 +92,33 @@ func NewConfig() *Config {
 // (e.g. config file paths and the WOL_CONFIG environment variable).
 func (c *Config) Sources() []string {
 	return c.sources
+}
+
+// MachineByName returns the configured machine with the given name
+// (case-insensitive).
+func (c *Config) MachineByName(name string) (Machine, error) {
+	for _, m := range c.Machines {
+		if strings.EqualFold(m.Name, name) {
+			return m, nil
+		}
+	}
+
+	return Machine{}, fmt.Errorf("machine with name %q not found", name)
+}
+
+// BroadcastFor returns the effective broadcast target for a machine: the global
+// broadcast setting with any non-zero per-machine override fields applied on top.
+func (c *Config) BroadcastFor(m Machine) Broadcast {
+	b := c.Broadcast
+	if m.Broadcast != nil {
+		if m.Broadcast.Address != "" {
+			b.Address = m.Broadcast.Address
+		}
+		if m.Broadcast.Port != 0 {
+			b.Port = m.Broadcast.Port
+		}
+	}
+	return b
 }
 
 // Load loads the configuration. The contributing sources are recorded and can be
@@ -131,6 +186,10 @@ func (c *Config) load(paths []string, explicit bool) ([]string, error) {
 		},
 		Ping: Ping{
 			Privileged: false,
+		},
+		Broadcast: Broadcast{
+			Address: "255.255.255.255",
+			Port:    9,
 		},
 	}
 	if err := k.Load(structs.Provider(defaults, koanfTag), nil); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,15 @@ type Machine struct {
 	Broadcast *Broadcast `koanf:"broadcast"`
 }
 
+// HardwareAddr parses and returns the machine's MAC address.
+func (m Machine) HardwareAddr() (net.HardwareAddr, error) {
+	mac, err := net.ParseMAC(m.Mac)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse MAC address: %w", err)
+	}
+	return mac, nil
+}
+
 // Broadcast is the destination a magic packet is sent to. It is reused for the
 // global default and for per-machine overrides; on an override, a zero-value
 // field (empty Address or zero Port) inherits the global value.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,6 +142,24 @@ machines:
 	assert.Equal(t, "192.168.20.255:7", c.BroadcastFor(c.Machines[0]).Addr())
 }
 
+func TestLoadGlobalBroadcastPartialKeepsDefaultPort(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	// Only the address is set globally; the port must fall back to the default 9
+	// (relies on config layers merging per key rather than replacing the block).
+	file := writeConfig(t, `
+broadcast:
+  address: "192.168.0.255"
+`)
+
+	c := NewConfig()
+	_, err := c.load([]string{file}, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "192.168.0.255", c.Broadcast.Address)
+	assert.Equal(t, 9, c.Broadcast.Port)
+}
+
 func TestLoadFilePrecedence(t *testing.T) {
 	t.Setenv(configEnvVar, "")
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,6 +106,15 @@ func TestMachineByName(t *testing.T) {
 	}
 }
 
+func TestMachineHardwareAddr(t *testing.T) {
+	mac, err := Machine{Mac: "01:02:03:04:05:06"}.HardwareAddr()
+	require.NoError(t, err)
+	assert.Equal(t, "01:02:03:04:05:06", mac.String())
+
+	_, err = Machine{Mac: "not-a-mac"}.HardwareAddr()
+	require.Error(t, err)
+}
+
 func TestLoadBroadcastFromFile(t *testing.T) {
 	t.Setenv(configEnvVar, "")
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,8 +27,110 @@ func TestLoadDefaults(t *testing.T) {
 	assert.Equal(t, ":7777", c.Server.Listen)
 	assert.False(t, c.Ping.Privileged)
 	assert.Empty(t, c.Machines)
+	// The broadcast target defaults to the limited broadcast on port 9.
+	assert.Equal(t, "255.255.255.255", c.Broadcast.Address)
+	assert.Equal(t, 9, c.Broadcast.Port)
 	// Defaults alone are not a config "source".
 	assert.Empty(t, sources)
+}
+
+func TestBroadcastForResolution(t *testing.T) {
+	c := &Config{Broadcast: Broadcast{Address: "255.255.255.255", Port: 9}}
+
+	tests := []struct {
+		name    string
+		machine Machine
+		want    Broadcast
+	}{
+		{
+			name:    "no override inherits global",
+			machine: Machine{Name: "a"},
+			want:    Broadcast{Address: "255.255.255.255", Port: 9},
+		},
+		{
+			name:    "full override",
+			machine: Machine{Name: "b", Broadcast: &Broadcast{Address: "192.168.1.255", Port: 7}},
+			want:    Broadcast{Address: "192.168.1.255", Port: 7},
+		},
+		{
+			name:    "address-only override inherits port",
+			machine: Machine{Name: "c", Broadcast: &Broadcast{Address: "192.168.20.255"}},
+			want:    Broadcast{Address: "192.168.20.255", Port: 9},
+		},
+		{
+			name:    "port-only override inherits address",
+			machine: Machine{Name: "d", Broadcast: &Broadcast{Port: 7}},
+			want:    Broadcast{Address: "255.255.255.255", Port: 7},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.BroadcastFor(tt.machine)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBroadcastAddr(t *testing.T) {
+	assert.Equal(t, "192.168.1.255:9", Broadcast{Address: "192.168.1.255", Port: 9}.Addr())
+}
+
+func TestMachineByName(t *testing.T) {
+	c := &Config{Machines: []Machine{
+		{Name: "alpha", Mac: "01:02:03:04:05:06"},
+		{Name: "beta", Mac: "0a:0b:0c:0d:0e:0f"},
+	}}
+
+	tests := []struct {
+		name      string
+		lookup    string
+		wantName  string
+		wantError bool
+	}{
+		{name: "exact match", lookup: "alpha", wantName: "alpha"},
+		{name: "case-insensitive match", lookup: "ALPHA", wantName: "alpha"},
+		{name: "not found", lookup: "ghost", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			machine, err := c.MachineByName(tt.lookup)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, machine.Name)
+		})
+	}
+}
+
+func TestLoadBroadcastFromFile(t *testing.T) {
+	t.Setenv(configEnvVar, "")
+
+	file := writeConfig(t, `
+broadcast:
+  address: "192.168.0.255"
+  port: 7
+machines:
+  - name: alpha
+    mac: "01:02:03:04:05:06"
+    broadcast:
+      address: "192.168.20.255"
+`)
+
+	c := NewConfig()
+	_, err := c.load([]string{file}, false)
+	require.NoError(t, err)
+
+	// Global broadcast comes from the file.
+	assert.Equal(t, "192.168.0.255", c.Broadcast.Address)
+	assert.Equal(t, 7, c.Broadcast.Port)
+
+	// The per-machine override sets only the address, inheriting the global port.
+	require.Len(t, c.Machines, 1)
+	assert.Equal(t, "192.168.20.255:7", c.BroadcastFor(c.Machines[0]).Addr())
 }
 
 func TestLoadFilePrecedence(t *testing.T) {

--- a/magicpacket/magicpacket.go
+++ b/magicpacket/magicpacket.go
@@ -1,6 +1,7 @@
 package magicpacket
 
 import (
+	"fmt"
 	"io"
 	"net"
 )
@@ -10,8 +11,6 @@ const (
 	packetSize     = 102
 	syncStreamSize = 6
 	macRepeatCount = 16
-
-	broadcastPort = 9
 )
 
 // MagicPacket represents a wake-on-LAN packet
@@ -44,14 +43,16 @@ func (p *MagicPacket) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-// Broadcast sends the magic packet to the broadcast address
-func (p *MagicPacket) Broadcast() (err error) {
-	// TODO: broadcast to more common ports and addresses?
-	addr := &net.UDPAddr{
-		IP:   net.IPv4bcast,
-		Port: broadcastPort,
+// Broadcast sends the magic packet to addr, a "host:port" broadcast target such
+// as "255.255.255.255:9" or a subnet-directed broadcast like "192.168.1.255:9".
+// A subnet-directed broadcast is routed out the interface owning that subnet,
+// which is what makes waking devices reliable on multi-homed hosts.
+func (p *MagicPacket) Broadcast(addr string) (err error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return fmt.Errorf("invalid broadcast address %q: %w", addr, err)
 	}
-	conn, err := net.DialUDP("udp", nil, addr)
+	conn, err := net.DialUDP("udp", nil, udpAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Magic packets were always sent to 255.255.255.255:9. On a host with more than one network interface (for example WSL2, or a host with Docker bridges), the OS can send that broadcast out the wrong interface, so the device never wakes.

You can now set the broadcast address and port in three places:

- Globally, under the `broadcast` config key.
- Per machine, under a machine's own `broadcast` key. Fields you leave out fall back to the global value.
- Per send, with the `--broadcast` and `--port` flags.

Precedence is CLI flag, then per-machine config, then global config, then the 255.255.255.255:9 default. The default is unchanged, so existing configs keep working. The HTTP wake endpoint uses the per-machine value too.

Example config:

```yaml
broadcast:
  address: "255.255.255.255"
  port: 9
machines:
  - name: nas
    mac: "AA:BB:CC:DD:EE:FF"
    broadcast:
      address: "192.168.20.255"
```

Tested with go build, go vet, go test, and real sends to both the default and a subnet-directed broadcast.

Part of ME-18
