### PR TITLE
fix: preserve non-ASCII machine names in flash cookie

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -140,16 +141,17 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// setFlashMessage sets a flash message in a cookie
+// setFlashMessage stores a flash message in a cookie, URL-encoded so non-ASCII
+// bytes survive net/http's cookie-value validation rather than being dropped.
 func setFlashMessage(w http.ResponseWriter, message string) {
 	http.SetCookie(w, &http.Cookie{
 		Name:  "flash",
-		Value: message,
+		Value: url.QueryEscape(message),
 		Path:  "/",
 	})
 }
 
-// consumeFlashMessage retrieves and clears the flash message from the request
+// consumeFlashMessage retrieves, decodes, and clears the flash message cookie.
 func consumeFlashMessage(w http.ResponseWriter, r *http.Request) string {
 	cookie, err := r.Cookie("flash")
 	if err == nil {
@@ -161,6 +163,10 @@ func consumeFlashMessage(w http.ResponseWriter, r *http.Request) string {
 			Expires: time.Now().Add(-1 * time.Hour),
 		})
 
+		// Fall back to the raw value if decoding fails.
+		if message, err := url.QueryUnescape(cookie.Value); err == nil {
+			return message
+		}
 		return cookie.Value
 	}
 	return ""

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -131,6 +132,37 @@ func TestHandleWakeSuccess(t *testing.T) {
 	}
 	require.NotNil(t, flash)
 	assert.Contains(t, flash.Value, "alpha")
+}
+
+// Non-ASCII machine names must survive the flash cookie round-trip (issue #35).
+func TestHandleWakeNonASCIIName(t *testing.T) {
+	const machineName = "客厅电脑"
+	cfg := &config.Config{
+		Broadcast: config.Broadcast{Address: "255.255.255.255", Port: 9},
+		Machines:  []config.Machine{{Name: machineName, Mac: "01:02:03:04:05:06"}},
+	}
+
+	wake := func(mac net.HardwareAddr, addr string) error { return nil }
+	body := "name=" + url.QueryEscape(machineName)
+	req := httptest.NewRequest(http.MethodPost, "/wake", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	newServer(cfg, nil, wake).routes().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusSeeOther, rec.Code)
+
+	var flash *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "flash" {
+			flash = c
+		}
+	}
+	require.NotNil(t, flash)
+
+	// Decoded value must preserve the non-ASCII name (no bytes dropped).
+	got, err := url.QueryUnescape(flash.Value)
+	require.NoError(t, err)
+	assert.Contains(t, got, machineName)
 }
 
 func TestHandleWakeMachineNotFound(t *testing.T) {


### PR DESCRIPTION
## Problem

Reported in #35: a machine named with non-ASCII characters (e.g. `戴尔192.168.1.101`) logs this on every wake:

```
Sending magic packet to b3:6b:25:1d:3c:cb via 255.255.255.255:9
net/http: invalid byte 'æ' in Cookie.Value; dropping invalid bytes
```

`handleWake` builds a confirmation message embedding the machine name and stores it verbatim as the `flash` cookie value. Go's `net/http` validates cookie values per RFC 6265 and **drops the non-ASCII bytes**, logging the warning and mangling the banner (`戴尔` disappears, leaving `…sent to 192.168.1.101…`).

This is **not a regression** — the flash cookie has worked this way since `a9b8cb3` (present since v0.0.3). And it is **not blocking**: the magic packet is sent *before* the cookie is written and succeeds, so wake-on-LAN is unaffected. The fix removes the log noise and restores the confirmation text.

## Fix

URL-encode the cookie value (`url.QueryEscape` on write, `url.QueryUnescape` on read, falling back to the raw value on a decode error). `QueryEscape` output is always a valid cookie value and round-trips the full name. No template change is needed — `html/template` still escapes the decoded message at render time.

## Test

Added `TestHandleWakeNonASCIIName`, which wakes a machine named `戴尔192.168.1.101` and asserts the `flash` cookie decodes back to the full name with no bytes dropped. `go test ./...`, `go vet ./...`, and `go build ./...` all pass.

Closes #35
Closes ME-28